### PR TITLE
Add jquery-ui-rails to the default gemset

### DIFF
--- a/recipes/gemfile.rb
+++ b/recipes/gemfile.rb
@@ -72,7 +72,7 @@ end
 if @template_options[:active_admin]
   insert_into_file 'Gemfile', :after => "gem 'jquery-rails'\n" do
     "gem 'activeadmin'\n"
-    "gem 'jquery-ui-rails'\n"
+    "gem 'jquery-ui-rails', '2.3.0'\n"
   end
   insert_into_file 'config/environments/development.rb', "\n  config.action_mailer.default_url_options = { :host => 'localhost:3000' }\n", :before => /^end$/
 end


### PR DESCRIPTION
The jquery-rails gem just removed jquery-ui and ActiveAdmin depends on
jquery-ui.
