### PR TITLE
Renamed content blocks for expanded use cases.

### DIFF
--- a/preseason/templates/playbook/app/views/layouts/application.html.erb
+++ b/preseason/templates/playbook/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   <%= csrf_meta_tags %>
   <%= javascript_include_tag :modernizr %>
   <link rel="apple-touch-icon-precomposed" href="apple-touch-icon.png">
+  <%= yield :head %>
 </head>
 <body>
 
@@ -20,7 +21,7 @@
     <%= javascript_include_tag 'ie8' %>
   <![endif]-->
   <%= javascript_include_tag "application" %>
-  <%# all page specific javascript so go into content_for(:extra_js) %>
-  <%= yield :extra_js %>
+  <%# All page specific JavaScript so go into content_for(:body_close) %>
+  <%= yield :body_close %>
 </body>
 </html>


### PR DESCRIPTION
I've found that there are several scenarios where the content block `:extra_js` name does not make much sense. I think we'd be better served with `:head` and `:body_end` content blocks. Here are some scenario examples:
- [Including page-specific modal markup on top level body so that it works in Firefox](https://github.com/centresource/athlete-endeavors/blob/8a4e3be394dbee40ab50c68c86d6a99809617a5e/app/views/athletes/index.html.erb#L50-L52)
- [Including JavaScript/stylesheets in the head and JavaScript in the body for MapBox to initialize properly](https://github.com/centresource/cs-website/blob/master/app/views/site/contact.html.erb#L1-L14)
