### PR TITLE
Add update to extra_js call to make it more semantic

### DIFF
--- a/preseason/templates/playbook/app/views/layouts/application.html.erb
+++ b/preseason/templates/playbook/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
     <%= yield %>
 
     <%= javascript_include_tag 'application' %>
-    <%# all page specific javascript so go into content_for(:extra_js) %>
-    <%= yield :extra_js %>
+    <%# all page-specific content to go into content_for(:body_close) %>
+    <%= yield :body_close %>
   </body>
 </html>


### PR DESCRIPTION
Change the symbol to not be bound to the content be js. @dcalhoun 's suggestion to make it descriptive of where the content is going instead of what it contains.

\cc @brandonvalentine 